### PR TITLE
:GB: fix

### DIFF
--- a/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
+++ b/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
@@ -14,7 +14,7 @@ PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_DESC="Enter the App ID for your custom F
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPSECRET_LABEL="Facebook Application Secret"
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPSECRET_DESC="Enter the App Secret for your custom Facebook application here. This is required to enable social login with Facebook. You can create a Facebook app at https://developers.facebook.com/apps."
 PLG_AUTHENTICATION_FACEBOOK_FIELD_CREATENEW_LABEL="Create new user accounts?"
-PLG_AUTHENTICATION_FACEBOOK_FIELD_CREATENEW_DESC="Creates a new Joomla! user when a user tries to log in via Facebook but there is no Joomla! user account associated with that e-mail or Facebook User ID. If user registration is disabled no account will be created and an error will be raised. The Joomla! user has a username derived from the Facebook login, the same email address as the Facebook account and a long, random password (which the user can change once they have logged in). Set this to No to prevent creation of user accounts through Facebook login."
+PLG_AUTHENTICATION_FACEBOOK_FIELD_CREATENEW_DESC="Creates a new Joomla! user when a user tries to log in via Facebook but there is no Joomla! user account associated with that email or Facebook User ID. If user registration is disabled no account will be created and an error will be raised. The Joomla! user has a username derived from the Facebook login, the same email address as the Facebook account and a long, random password (which the user can change once they have logged in). Set this to No to prevent creation of user accounts through Facebook login."
 
 PLG_AUTHENTICATION_FACEBOOK_BTN_LABEL="Facebook Login"
 

--- a/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
+++ b/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
@@ -7,7 +7,7 @@
 ; of the string's context!
 
 PLG_AUTHENTICATION_FACEBOOK="Authentication - Facebook"
-PLG_AUTHENTICATION_FACEBOOK_XML_DESCRIPTION="Handles User Authentication with a Facebook account (Requires cURL).<br />You need to <a href='https://developers.facebook.com/apps'>create a Facebook app</a> for your site. Facebook login only works in the front-end of your site.<br /><strong>Warning!</strong>Facebook login bypasses Two Factor Authentication.<br /><strong> Warning! You must have at least one authentication plugin enabled or you will lose all access to your site.</strong>"
+PLG_AUTHENTICATION_FACEBOOK_XML_DESCRIPTION="Handles User Authentication with a Facebook account (Requires cURL).<br />You need to <a href='https://developers.facebook.com/apps'>create a Facebook app</a> for your site. Facebook login only works in the frontend of your site.<br /><strong>Warning!</strong>Facebook login bypasses Two Factor Authentication.<br /><strong> Warning! You must have at least one authentication plugin enabled or you will lose all access to your site.</strong>"
 
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_LABEL="Facebook Application ID"
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_DESC="Enter the App ID for your custom Facebook application here. This is required to enable social login with Facebook. You can create a Facebook app at https://developers.facebook.com/apps."


### PR DESCRIPTION
:gb: Following the https://joomla.github.io/user-interface-text/?user-interface-text/words2watch.md `front-end` should be `frontend`
also turned one `e-mail` to `email`