### PR TITLE
Set up Crowdin sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /.gitignore
+/composer.lock
 /release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Forces new Travis-CI Infrastructure
+sudo: false
+
+language: php
+
+env:
+  global:
+    - secure: "DsJNBcvx+7FxsUi3vx9ey4VLoyMMXj2GVHT/ckoXjMW5VyCU20lv6U/vkvWVFdML3Dqg5fLfonucF3gblB/KjGEcYpMPB10nEVzHsVOTH/M1m41+51REb+S/HNC/DuRJsmhvuddzXdI5yEl6Mk8PBSK21adx0QLsrkCYZ2YEcmAywdqPhTGWwgc6GoTYSEBkDGRO+r2vw7CvzlzjzF92UiNTKxBQJALV0Rn1h3rmViD0ZZgdPfsdLinZK5bcGGO/6/7lpFm1GcSPPDZM2IlrXEZTE43IMb7+g7qFgJqUzKkCYskzHbU26ZXSP6P2Oob44kgCLbsmwzDIinqVm0bpIebtknH7EbeJ9fzBv/W4tSUGjj7hhfa2gE6fvMeomui8R3Vt0Lwye2D3Iz8Se4rj4nmXKFN6StDY/KwjhrD49k+cM3jd3naW46gMnxNuzpjEruaFR6r3wVCRsKrIoMB0anJNx9qaEQdPcHlt27EImlxCWisG9kcD98NG1pnHOflQs1HEKwaPeOYMWq+gyaV/N3hedlHH2QoUxCGU4fpt/QA+dmS7/niWf6LFYieF2EAj5R9ii5yyQOlwmMxg2wacPIT1WJMljgpUTTmGqncNvz1zTJN7SvRGwQ/uP+ITwnjHXhD2i4LHHwf4i1CAJtYqdqftpA4yBasBFiM3d8aVD3c="
+    - UPDATE_CROWDIN="no"
+
+matrix:
+  include:
+    - php: 7.0
+      env: UPDATE_CROWDIN="yes"
+
+before_script:
+  # Make sure all dev dependencies are installed
+  - composer install
+
+script:
+  - if [[ $UPDATE_CROWDIN == "yes" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]; then vendor/bin/crowdin --upload; fi

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "joomla-extensions/facebook-auth",
+    "type": "project",
+    "description": "Joomla! Facebook Authentication Plugin",
+    "keywords": ["joomla", "cms"],
+    "homepage": "https://github.com/joomla-extensions/facebook-auth",
+    "license": "GPL-2.0+",
+    "require": {
+        "php": ">=5.3.10"
+    },
+    "require-dev": {
+        "joomla/crowdin-sync": "dev-master"
+    }
+}

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,0 +1,13 @@
+project_identifier: joomla-patchtester
+api_key_env: 'CROWDIN_API_KEY'
+base_path: ./plugins/authentication/facebook/language
+
+files:
+  -
+    source: /en-GB/en-GB.plg_authentication_facebook.ini
+    dest: plg_authentication_facebook/en-GB.plg_authentication_facebook.ini
+    translation: /%locale%/%locale%.plg_authentication_facebook.ini
+  -
+    source: /en-GB/en-GB.plg_authentication_facebook.sys.ini
+    dest: plg_authentication_facebook/en-GB.plg_authentication_facebook.sys.ini
+    translation: /%locale%/%locale%.plg_authentication_facebook.sys.ini


### PR DESCRIPTION
#### Summary of Changes

- Adds a Composer manifest to the repo to import the [Crowdin sync](https://github.com/joomla-projects/crowdin-sync) tool
- Adds a `crowdin.yaml` file to the repo with the Crowdin configuration mappings
- Adds a `.travis.yml` file to the repo configuring a Travis job to automatically push language file updates to [the Crowdin project](https://crowdin.com/project/joomla-patchtester) when a commit is pushed to the master branch

#### Testing Instructions

To use this tool without Travis, run `composer install` then one of these two commands:

- `vendor/bin/crowdin --upload --crowdin-api-key="API_KEY"` to upload the source files to Crowdin
- `vendor/bin/crowdin --download --crowdin-api-key="API_KEY"` to download the translated files from Crowdin

For obvious reasons the API key isn't shared publicly (and is encrypted into the Travis config); can provide it privately for anyone with a need.