### PR TITLE
Removing (.) from the link

### DIFF
--- a/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
+++ b/plugins/authentication/facebook/language/en-GB/en-GB.plg_authentication_facebook.ini
@@ -10,7 +10,7 @@ PLG_AUTHENTICATION_FACEBOOK="Authentication - Facebook"
 PLG_AUTHENTICATION_FACEBOOK_XML_DESCRIPTION="Handles User Authentication with a Facebook account (Requires cURL).<br />You need to <a href='https://developers.facebook.com/apps'>create a Facebook app</a> for your site. Facebook login only works in the frontend of your site.<br /><strong>Warning!</strong>Facebook login bypasses Two Factor Authentication.<br /><strong> Warning! You must have at least one authentication plugin enabled or you will lose all access to your site.</strong>"
 
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_LABEL="Facebook Application ID"
-PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_DESC="Enter the App ID for your custom Facebook application here. This is required to enable social login with Facebook. You can create a Facebook app at https://developers.facebook.com/apps."
+PLG_AUTHENTICATION_FACEBOOK_FIELD_APPID_DESC="Enter the App ID for your custom Facebook application here. This is required to enable social login with Facebook. You can create a Facebook app at https://developers.facebook.com/apps"
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPSECRET_LABEL="Facebook Application Secret"
 PLG_AUTHENTICATION_FACEBOOK_FIELD_APPSECRET_DESC="Enter the App Secret for your custom Facebook application here. This is required to enable social login with Facebook. You can create a Facebook app at https://developers.facebook.com/apps."
 PLG_AUTHENTICATION_FACEBOOK_FIELD_CREATENEW_LABEL="Create new user accounts?"


### PR DESCRIPTION
Following
https://crowdin.com/translate/joomla-patchtester/527/engb-it#19001

https://developers.facebook.com/apps. The dot at the end of the string can create issues with the link.